### PR TITLE
Supported proposals config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "soroban-governor-ui",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "soroban-governor-ui",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "dependencies": {
         "@creit.tech/stellar-wallets-kit": "1.3.0",
         "@headlessui/react": "^1.7.18",

--- a/src/pages/[dao]/propose.tsx
+++ b/src/pages/[dao]/propose.tsx
@@ -259,10 +259,9 @@ export default function CreateProposal() {
           }
           setCalldataSimSuccess(true);
           setCalldataSimResult(
-            `Successfully simulated. ${
-              retval === ""
-                ? "No return value detected."
-                : `Return Value: \n ${JSON.stringify(retval, jsonReplacer, 2)}`
+            `Successfully simulated. ${retval === ""
+              ? "No return value detected."
+              : `Return Value: \n ${JSON.stringify(retval, jsonReplacer, 2)}`
             }`
           );
         } else if (rpc.Api.isSimulationRestore(result)) {
@@ -288,6 +287,11 @@ export default function CreateProposal() {
       console.error(e);
     }
   }
+
+  const isCalldataSupported = (currentGovernor?.supportedProposalTypes ?? [ProposalActionEnum.CALLDATA]).includes(ProposalActionEnum.CALLDATA);
+  const isCouncilSupported = (currentGovernor?.supportedProposalTypes ?? [ProposalActionEnum.COUNCIL]).includes(ProposalActionEnum.COUNCIL);
+  const isSettingsSupported = (currentGovernor?.supportedProposalTypes ?? [ProposalActionEnum.SETTINGS]).includes(ProposalActionEnum.SETTINGS);
+  const isSnapshotSupported = (currentGovernor?.supportedProposalTypes ?? [ProposalActionEnum.SNAPSHOT]).includes(ProposalActionEnum.SNAPSHOT);
 
   return (
     <Container className="flex flex-col lg:flex-row gap-4">
@@ -321,70 +325,74 @@ export default function CreateProposal() {
 
         <Container slim className=" flex flex-col gap-0 ">
           <Typography.P className="text-snapLink">Proposal type</Typography.P>
-          <RadioButton
-            endText="DAO will submit a transaction"
-            selected={proposalAction === ProposalActionEnum.CALLDATA}
-            onChange={() => {
-              setProposalAction(ProposalActionEnum.CALLDATA);
-            }}
-            label={
-              <Chip
-                className={`${
-                  classByProposalAction[ProposalActionEnum.CALLDATA]
-                } !py-4`}
-              >
-                {ProposalActionEnum.CALLDATA}
-              </Chip>
-            }
-          />
-          <RadioButton
-            endText="Change the security council of the DAO"
-            selected={proposalAction === ProposalActionEnum.COUNCIL}
-            onChange={() => {
-              setProposalAction(ProposalActionEnum.COUNCIL);
-            }}
-            label={
-              <Chip
-                className={`${
-                  classByProposalAction[ProposalActionEnum.COUNCIL]
-                } !py-4`}
-              >
-                {ProposalActionEnum.COUNCIL}
-              </Chip>
-            }
-          />
-          <RadioButton
-            endText="Change the settings of the DAO"
-            selected={proposalAction === ProposalActionEnum.SETTINGS}
-            onChange={() => {
-              setProposalAction(ProposalActionEnum.SETTINGS);
-            }}
-            label={
-              <Chip
-                className={`${
-                  classByProposalAction[ProposalActionEnum.SETTINGS]
-                } !py-4`}
-              >
-                {ProposalActionEnum.SETTINGS}
-              </Chip>
-            }
-          />
-          <RadioButton
-            endText="No execution action"
-            selected={proposalAction === ProposalActionEnum.SNAPSHOT}
-            onChange={() => {
-              setProposalAction(ProposalActionEnum.SNAPSHOT);
-            }}
-            label={
-              <Chip
-                className={`${
-                  classByProposalAction[ProposalActionEnum.SNAPSHOT]
-                } !py-4`}
-              >
-                {ProposalActionEnum.SNAPSHOT}
-              </Chip>
-            }
-          />
+          {isCalldataSupported && (
+            <RadioButton
+              endText="DAO will submit a transaction"
+              selected={proposalAction === ProposalActionEnum.CALLDATA}
+              onChange={() => {
+                setProposalAction(ProposalActionEnum.CALLDATA);
+              }}
+              label={
+                <Chip
+                  className={`${classByProposalAction[ProposalActionEnum.CALLDATA]
+                    } !py-4`}
+                >
+                  {ProposalActionEnum.CALLDATA}
+                </Chip>
+              }
+            />
+          )}
+          {isCouncilSupported && (
+            <RadioButton
+              endText="Change the security council of the DAO"
+              selected={proposalAction === ProposalActionEnum.COUNCIL}
+              onChange={() => {
+                setProposalAction(ProposalActionEnum.COUNCIL);
+              }}
+              label={
+                <Chip
+                  className={`${classByProposalAction[ProposalActionEnum.COUNCIL]
+                    } !py-4`}
+                >
+                  {ProposalActionEnum.COUNCIL}
+                </Chip>
+              }
+            />
+          )}
+          {isSettingsSupported && (
+            <RadioButton
+              endText="Change the settings of the DAO"
+              selected={proposalAction === ProposalActionEnum.SETTINGS}
+              onChange={() => {
+                setProposalAction(ProposalActionEnum.SETTINGS);
+              }}
+              label={
+                <Chip
+                  className={`${classByProposalAction[ProposalActionEnum.SETTINGS]
+                    } !py-4`}
+                >
+                  {ProposalActionEnum.SETTINGS}
+                </Chip>
+              }
+            />
+          )}
+          {isSnapshotSupported && (
+            <RadioButton
+              endText="No execution action"
+              selected={proposalAction === ProposalActionEnum.SNAPSHOT}
+              onChange={() => {
+                setProposalAction(ProposalActionEnum.SNAPSHOT);
+              }}
+              label={
+                <Chip
+                  className={`${classByProposalAction[ProposalActionEnum.SNAPSHOT]
+                    } !py-4`}
+                >
+                  {ProposalActionEnum.SNAPSHOT}
+                </Chip>
+              }
+            />
+          )}
         </Container>
         {!isPreview && (
           <>
@@ -431,7 +439,7 @@ export default function CreateProposal() {
                           ? stringify(simulatedCallDataAuth, null, 2)
                           : ""
                       }
-                      onChange={() => {}}
+                      onChange={() => { }}
                       placeholder={"No Auth Required"}
                       disabled={true}
                     />
@@ -455,7 +463,7 @@ export default function CreateProposal() {
                         key={index}
                         calldata={auth}
                         isAuth={true}
-                        onChange={() => {}}
+                        onChange={() => { }}
                       />
                     ))}
                   </>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -105,6 +105,7 @@ export interface Governor {
   isWrappedAsset: boolean;
   underlyingTokenAddress?: string;
   underlyingTokenMetadata?: TokenMetadata;
+  supportedProposalTypes?: string[]
 }
 
 export interface Vote {


### PR DESCRIPTION
On create proposal page display only those proposal types which are specified in the config file. If field isn't present in config, assume all types are supported and display all buttons

`"supportedProposalTypes": ["Calldata", "Snapshot", "Settings", "Council"],`