### PR TITLE
Display total issued token amount

### DIFF
--- a/public/governors/governors-testnet.json
+++ b/public/governors/governors-testnet.json
@@ -42,7 +42,6 @@
       "symbol": "SCF",
       "decimals": 9,
       "icon": "https://cdn.sanity.io/images/thmxviu9/public/7bbb944ce610aea39c8bbe71c9dd8e75017ad3a2-1649x1649.png"
-    },
-    "displayProposalThreshold": false
+    }
   }
 ]

--- a/src/pages/[dao]/about.tsx
+++ b/src/pages/[dao]/about.tsx
@@ -84,14 +84,10 @@ function About() {
           <Typography.Small className="text-snapLink pl-2">
             {`${settings.grace_period} ledgers`}
           </Typography.Small>
-          {currentGovernor.displayProposalThreshold !== false && (
-            <>
-              <Typography.P>Proposal Threshold</Typography.P>
-              <Typography.Small className="text-snapLink pl-2">
-                {`${toBalance(settings.proposal_threshold, currentGovernor.decimals)} ${currentGovernor.voteTokenMetadata?.symbol}`}
-              </Typography.Small>
-            </>
-          )}
+          <Typography.P>Proposal Threshold</Typography.P>
+          <Typography.Small className="text-snapLink pl-2">
+            {`${toBalance(settings.proposal_threshold, currentGovernor.decimals)} ${currentGovernor.voteTokenMetadata?.symbol}`}
+          </Typography.Small>
           <Typography.P>Quorum</Typography.P>
           <Typography.Small className="text-snapLink pl-2">
             {`${settings.quorum / 100}%`}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -111,9 +111,8 @@ export interface Governor {
   isWrappedAsset: boolean;
   underlyingTokenAddress?: string;
   underlyingTokenMetadata?: TokenMetadata;
-  supportedProposalTypes?: string[];
-  delegation?: boolean;
-  displayProposalThreshold?: boolean
+  supportedProposalTypes?: string[]
+  delegation?: boolean
 }
 
 export interface Vote {


### PR DESCRIPTION
In "Your Votes" section display total amount of token issued by calling `total_amount()` function on token contract.
Added to allow better understanding how many votes are issued, so users can better see how much token is needed to make proposal pass as valid. Right now we only have "Quorum" percentage value, which doesn't say much if we don't know how much token is issued.