### PR TITLE
Optionally don't display proposal threshold

### DIFF
--- a/public/governors/governors-testnet.json
+++ b/public/governors/governors-testnet.json
@@ -42,6 +42,7 @@
       "symbol": "SCF",
       "decimals": 9,
       "icon": "https://cdn.sanity.io/images/thmxviu9/public/7bbb944ce610aea39c8bbe71c9dd8e75017ad3a2-1649x1649.png"
-    }
+    },
+    "displayProposalThreshold": false
   }
 ]

--- a/src/pages/[dao]/about.tsx
+++ b/src/pages/[dao]/about.tsx
@@ -84,10 +84,14 @@ function About() {
           <Typography.Small className="text-snapLink pl-2">
             {`${settings.grace_period} ledgers`}
           </Typography.Small>
-          <Typography.P>Proposal Threshold</Typography.P>
-          <Typography.Small className="text-snapLink pl-2">
-            {`${toBalance(settings.proposal_threshold, currentGovernor.decimals)} ${currentGovernor.voteTokenMetadata?.symbol}`}
-          </Typography.Small>
+          {currentGovernor.displayProposalThreshold !== false && (
+            <>
+              <Typography.P>Proposal Threshold</Typography.P>
+              <Typography.Small className="text-snapLink pl-2">
+                {`${toBalance(settings.proposal_threshold, currentGovernor.decimals)} ${currentGovernor.voteTokenMetadata?.symbol}`}
+              </Typography.Small>
+            </>
+          )}
           <Typography.P>Quorum</Typography.P>
           <Typography.Small className="text-snapLink pl-2">
             {`${settings.quorum / 100}%`}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -111,8 +111,9 @@ export interface Governor {
   isWrappedAsset: boolean;
   underlyingTokenAddress?: string;
   underlyingTokenMetadata?: TokenMetadata;
-  supportedProposalTypes?: string[]
-  delegation?: boolean
+  supportedProposalTypes?: string[];
+  delegation?: boolean;
+  displayProposalThreshold?: boolean
 }
 
 export interface Vote {


### PR DESCRIPTION
Added optional boolean field to config `displayProposalThreshold`, which if set to false will make "Proposal Threshold" in governor settings invisible. Defaults to true. This is to minimize user confusion, sice we use our own _proposal creation whitelist system_ and ignore proposal threshold, thus making this info useless.
Updated our SCF dao config to work with this change